### PR TITLE
Fix loading gerbv on Linux

### DIFF
--- a/pygerbv/gerbv.py
+++ b/pygerbv/gerbv.py
@@ -13,8 +13,6 @@ from .structure import *
 library_path = find_library('gerbv')
 if not library_path:
     raise ModuleNotFoundError
-if platform.system() == 'Linux':
-    _libgerbv = CDLL('/usr/local/lib/' + library_path)
 else:
     _libgerbv = CDLL(library_path)
 


### PR DESCRIPTION
**Problem**

On modern ubuntu, and probably many other Linux distributions, the `gerbv` DLL is *not* in `/usr/local/lib/`. For example, for me, it is at `/usr/lib/x86_64-linux-gnu/libgerbv.so.1`.  This was hard-coded for some reason in 1288e132f753ce71472eb396a2e1aea6076add23, but the real fix for the problem was in ea39c5552febf6dfc050c91e4643b228a3912308, raising an exception when the library can't be identified. If it was identified, hardcoding the path is unlikely to help, and very likely to break things, as it does for me.

**Solution**

This change makes the library load correctly on linux by removing the check and just letting `find_library` and `CDLL` do their thing, as they were implemented to do.