### PR TITLE
prefer /usr/local/lib

### DIFF
--- a/pygerbv/gerbv.py
+++ b/pygerbv/gerbv.py
@@ -2,6 +2,7 @@
 
 from ctypes import *
 from ctypes.util import find_library
+from pathlib import Path
 import platform
 import tempfile
 
@@ -13,6 +14,10 @@ from .structure import *
 library_path = find_library('gerbv')
 if not library_path:
     raise ModuleNotFoundError
+local_lib = Path("/usr/local/lib")
+local_library = local_lib / library_path
+if local_library.is_file():
+    _libgerbv = CDLL(local_library)
 else:
     _libgerbv = CDLL(library_path)
 


### PR DESCRIPTION
ld.so.conf does not search for 64bit libraries in /usr/local/lib, but our install process puts gerbv libraries there. Prefer a library in that path, but fall back to OS library search